### PR TITLE
modbus-go: fix logical exceptions

### DIFF
--- a/pkg/modbus/config.go
+++ b/pkg/modbus/config.go
@@ -77,8 +77,7 @@ func (c *Config) parseFlags() error {
 	pflag.StringVar(&c.Mqtt.PrivateKey, "mqtt-priviatekey", c.Mqtt.PrivateKey, "private key file path")
 	pflag.Parse()
 
-	if (c.Mqtt.Cert != "" && c.Mqtt.PrivateKey == "") ||
-		(c.Mqtt.Cert == "" && c.Mqtt.PrivateKey != "") {
+	if c.Mqtt.Cert == "" || c.Mqtt.PrivateKey == "" {
 		return ErrConfigCert
 	}
 	return nil


### PR DESCRIPTION
Copy the PR from kubeedge/mappers/modbus-go, modbus-go: fix logical exceptions #2456.
soyoo@aliyun.com