### PR TITLE
delete binary of opcua mapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+pkg/opcua/opcua
+pkg/modbus/modbus
+.idea


### PR DESCRIPTION
Signed-off-by: Kevin Wang <kevinwzf0126@gmail.com>

We should not check-in the binary