### PR TITLE
Clean up of some issues.

### DIFF
--- a/build/crd-samples/devices/modbusrtu-device-instance.yaml
+++ b/build/crd-samples/devices/modbusrtu-device-instance.yaml
@@ -51,10 +51,10 @@ status:
       reported:
         metadata:
           timestamp: '1550049403598'
-          type: integer
+          type: int
         value: "1"
       desired:
         metadata:
           timestamp: '1550049403598'
-          type: integer
+          type: int
         value: "1"

--- a/build/crd-samples/devices/modbustcp-device-instance.yaml
+++ b/build/crd-samples/devices/modbustcp-device-instance.yaml
@@ -47,10 +47,10 @@ status:
       reported:
         metadata:
           timestamp: '1550049403598'
-          type: integer
+          type: int
         value: "0"
       desired:
         metadata:
           timestamp: '1550049403598'
-          type: integer
+          type: int
         value: "0"

--- a/build/crd-samples/devices/opcua-device.yaml
+++ b/build/crd-samples/devices/opcua-device.yaml
@@ -50,5 +50,5 @@ status:
       reported:
         metadata:
           timestamp: '1550049403598'
-          type: integer
+          type: int
         value: "0"

--- a/pkg/opcua/README.md
+++ b/pkg/opcua/README.md
@@ -21,3 +21,21 @@ Please configuration the device instance and device model. You could refer to th
   Float
   Double
 - The get device status function "driver.GetStatus" should be written depending the device.
+
+# Notice
+
+There's a bug about gopcua library. https://github.com/gopcua/opcua/issues/410.
+If you want to use username&password mode, please modify the file as this:
+vendor/github.com/gopcua/opcua/uasc/secure_channel_crypto.go line 67:
+
+```
+ 67 func (s *SecureChannel) EncryptUserPassword(policyURI, password string, cert, nonce []byte) ([]byte, string, error) {
+ 68     // If the User ID Token's policy was null, then default to the secure channel's policy
+ 69     if policyURI == "" {
+ 70         policyURI = s.cfg.SecurityPolicyURI
+ 71     }
+ 72
+ 73     if policyURI == ua.SecurityPolicyURINone {
+ 74         return []byte(password), "", nil
+ 75     }
+```


### PR DESCRIPTION
What type of PR is this?
/kind bug

What this PR does / why we need it:
1. The value type of twin could not be written as "integer" but "int".
2. Add notice for opcua usage.

Which issue(s) this PR fixes:
Fixes #19  #9