### PR TITLE
extract function validate device instance

### DIFF
--- a/pkg/ble/configmap/parse.go
+++ b/pkg/ble/configmap/parse.go
@@ -18,7 +18,6 @@ package configmap
 
 import (
 	"encoding/json"
-	"errors"
 	"io/ioutil"
 
 	"k8s.io/klog/v2"
@@ -45,75 +44,12 @@ func Parse(path string,
 
 	for i := 0; i < len(deviceProfile.DeviceInstances); i++ {
 		instance := deviceProfile.DeviceInstances[i]
-		j := 0
-		for j = 0; j < len(deviceProfile.Protocols); j++ {
-			if instance.ProtocolName == deviceProfile.Protocols[j].Name {
-				instance.PProtocol = deviceProfile.Protocols[j]
-				break
-			}
-		}
-		if j == len(deviceProfile.Protocols) {
-			err = errors.New("Protocol not found")
-			return err
-		}
-
-		if instance.PProtocol.Protocol != "bluetooth" {
+		err := common.ValidateProfileDeviceInstance(&instance, &deviceProfile, "bluetooth")
+		if err == common.ErrorProtocolNotExpected {
 			continue
-		}
-
-		for k := 0; k < len(instance.PropertyVisitors); k++ {
-			modelName := instance.PropertyVisitors[k].ModelName
-			propertyName := instance.PropertyVisitors[k].PropertyName
-			l := 0
-			for l = 0; l < len(deviceProfile.DeviceModels); l++ {
-				if modelName == deviceProfile.DeviceModels[l].Name {
-					m := 0
-					for m = 0; m < len(deviceProfile.DeviceModels[l].Properties); m++ {
-						if propertyName == deviceProfile.DeviceModels[l].Properties[m].Name {
-							instance.PropertyVisitors[k].PProperty = deviceProfile.DeviceModels[l].Properties[m]
-							break
-						}
-					}
-
-					if m == len(deviceProfile.DeviceModels[l].Properties) {
-						err = errors.New("Property not found")
-						return err
-					}
-					break
-				}
-			}
-			if l == len(deviceProfile.DeviceModels) {
-				err = errors.New("Device model not found")
-				return err
-			}
-		}
-
-		for k := 0; k < len(instance.Twins); k++ {
-			name := instance.Twins[k].PropertyName
-			l := 0
-			for l = 0; l < len(instance.PropertyVisitors); l++ {
-				if name == instance.PropertyVisitors[l].PropertyName {
-					instance.Twins[k].PVisitor = &instance.PropertyVisitors[l]
-					break
-				}
-			}
-			if l == len(instance.PropertyVisitors) {
-				return errors.New("PropertyVisitor not found")
-			}
-		}
-
-		for k := 0; k < len(instance.Datas.Properties); k++ {
-			name := instance.Datas.Properties[k].PropertyName
-			l := 0
-			for l = 0; l < len(instance.PropertyVisitors); l++ {
-				if name == instance.PropertyVisitors[l].PropertyName {
-					instance.Datas.Properties[k].PVisitor = &instance.PropertyVisitors[l]
-					break
-				}
-			}
-			if l == len(instance.PropertyVisitors) {
-				return errors.New("PropertyVisitor not found")
-			}
+		} else if err != nil {
+			klog.Errorf("validate device profile failed: %v", err)
+			return err
 		}
 
 		devices[instance.ID] = new(globals.BleDev)

--- a/pkg/common/event.go
+++ b/pkg/common/event.go
@@ -19,6 +19,7 @@ package common
 import (
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"regexp"
 	"time"
 
@@ -32,6 +33,8 @@ const (
 	TopicStateUpdate     = "$hw/events/device/%s/state/update"
 	TopicDataUpdate      = "$ke/events/device/%s/data/update"
 )
+
+var ErrorProtocolNotExpected = errors.New("protocol not expected")
 
 // MqttClient is parameters for Mqtt client.
 type MqttClient struct {
@@ -160,4 +163,112 @@ func CreateMessageState(state string) (msg []byte, err error) {
 func GetDeviceID(topic string) (id string) {
 	re := regexp.MustCompile(`hw/events/device/(.+)/twin/update/delta`)
 	return re.FindStringSubmatch(topic)[1]
+}
+
+// validateProfilePropertyVisitor validate device instance propertyVisitors
+func validateProfilePropertyVisitor(instance *DeviceInstance, deviceModels []DeviceModel) error {
+	for k := 0; k < len(instance.PropertyVisitors); k++ {
+		modelName := instance.PropertyVisitors[k].ModelName
+		propertyName := instance.PropertyVisitors[k].PropertyName
+		l := 0
+		for l = 0; l < len(deviceModels); l++ {
+			if modelName == deviceModels[l].Name {
+				m := 0
+				for m = 0; m < len(deviceModels[l].Properties); m++ {
+					if propertyName == deviceModels[l].Properties[m].Name {
+						instance.PropertyVisitors[k].PProperty = deviceModels[l].Properties[m]
+						break
+					}
+				}
+
+				if m == len(deviceModels[l].Properties) {
+					err := errors.New("Property not found")
+					return err
+				}
+				break
+			}
+		}
+		if l == len(deviceModels) {
+			err := errors.New("Device model not found")
+			return err
+		}
+	}
+	return nil
+}
+
+// validateProfileTwin validate device instance twins
+func validateProfileTwin(instance *DeviceInstance) error {
+	for k := 0; k < len(instance.Twins); k++ {
+		name := instance.Twins[k].PropertyName
+		l := 0
+		for l = 0; l < len(instance.PropertyVisitors); l++ {
+			if name == instance.PropertyVisitors[l].PropertyName {
+				instance.Twins[k].PVisitor = &instance.PropertyVisitors[l]
+				break
+			}
+		}
+		if l == len(instance.PropertyVisitors) {
+			return errors.New("PropertyVisitor not found")
+		}
+	}
+	return nil
+}
+
+// validateProfileData validate device instance data
+func validateProfileData(instance *DeviceInstance) error {
+	for k := 0; k < len(instance.Datas.Properties); k++ {
+		name := instance.Datas.Properties[k].PropertyName
+		l := 0
+		for l = 0; l < len(instance.PropertyVisitors); l++ {
+			if name == instance.PropertyVisitors[l].PropertyName {
+				instance.Datas.Properties[k].PVisitor = &instance.PropertyVisitors[l]
+				break
+			}
+		}
+		if l == len(instance.PropertyVisitors) {
+			return errors.New("PropertyVisitor not found")
+		}
+	}
+	return nil
+}
+
+// validateProfileProtocol validate device protocol
+func validateProfileProtocol(instance *DeviceInstance, protocols []Protocol, expectedProtocol string) error {
+	j := 0
+	for j = 0; j < len(protocols); j++ {
+		if instance.ProtocolName == protocols[j].Name {
+			instance.PProtocol = protocols[j]
+			break
+		}
+	}
+	if j == len(protocols) {
+		err := errors.New("Protocol not found")
+		return err
+	}
+
+	if instance.PProtocol.Protocol != expectedProtocol {
+		return ErrorProtocolNotExpected
+	}
+	return nil
+}
+
+// ValidateProfileDeviceInstance validate device instance
+func ValidateProfileDeviceInstance(instance *DeviceInstance, deviceProfile *DeviceProfile, protocol string) error {
+	if err := validateProfileProtocol(instance, deviceProfile.Protocols, protocol); err != nil {
+		return err
+	}
+
+	if err := validateProfilePropertyVisitor(instance, deviceProfile.DeviceModels); err != nil {
+		return err
+	}
+
+	if err := validateProfileTwin(instance); err != nil {
+		return err
+	}
+
+	if err := validateProfileData(instance); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/pkg/modbus/device/device.go
+++ b/pkg/modbus/device/device.go
@@ -109,7 +109,7 @@ func onMessage(client mqtt.Client, message mqtt.Message) {
 		dev.Instance.Twins[i].Desired.Value = twinValue
 		var visitorConfig configmap.ModbusVisitorConfig
 		if err := json.Unmarshal([]byte(dev.Instance.Twins[i].PVisitor.VisitorConfig), &visitorConfig); err != nil {
-			klog.Error("Unmarshal visitor config failed")
+			klog.Errorf("Unmarshal visitor config failed: %v", err)
 		}
 		setVisitor(&visitorConfig, &dev.Instance.Twins[i], dev.ModbusClient)
 	}

--- a/pkg/opcua/configmap/parse.go
+++ b/pkg/opcua/configmap/parse.go
@@ -18,7 +18,6 @@ package configmap
 
 import (
 	"encoding/json"
-	"errors"
 	"io/ioutil"
 
 	"k8s.io/klog/v2"
@@ -45,75 +44,12 @@ func Parse(path string,
 
 	for i := 0; i < len(deviceProfile.DeviceInstances); i++ {
 		instance := deviceProfile.DeviceInstances[i]
-		j := 0
-		for j = 0; j < len(deviceProfile.Protocols); j++ {
-			if instance.ProtocolName == deviceProfile.Protocols[j].Name {
-				instance.PProtocol = deviceProfile.Protocols[j]
-				break
-			}
-		}
-		if j == len(deviceProfile.Protocols) {
-			err = errors.New("Protocol not found")
-			return err
-		}
-
-		if instance.PProtocol.Protocol != "opcua" {
+		err := mappercommon.ValidateProfileDeviceInstance(&instance, &deviceProfile, "opcua")
+		if err == mappercommon.ErrorProtocolNotExpected {
 			continue
-		}
-
-		for k := 0; k < len(instance.PropertyVisitors); k++ {
-			modelName := instance.PropertyVisitors[k].ModelName
-			propertyName := instance.PropertyVisitors[k].PropertyName
-			l := 0
-			for l = 0; l < len(deviceProfile.DeviceModels); l++ {
-				if modelName == deviceProfile.DeviceModels[l].Name {
-					m := 0
-					for m = 0; m < len(deviceProfile.DeviceModels[l].Properties); m++ {
-						if propertyName == deviceProfile.DeviceModels[l].Properties[m].Name {
-							instance.PropertyVisitors[k].PProperty = deviceProfile.DeviceModels[l].Properties[m]
-							break
-						}
-					}
-
-					if m == len(deviceProfile.DeviceModels[l].Properties) {
-						err = errors.New("Property not found")
-						return err
-					}
-					break
-				}
-			}
-			if l == len(deviceProfile.DeviceModels) {
-				err = errors.New("Device model not found")
-				return err
-			}
-		}
-
-		for k := 0; k < len(instance.Twins); k++ {
-			name := instance.Twins[k].PropertyName
-			l := 0
-			for l = 0; l < len(instance.PropertyVisitors); l++ {
-				if name == instance.PropertyVisitors[l].PropertyName {
-					instance.Twins[k].PVisitor = &instance.PropertyVisitors[l]
-					break
-				}
-			}
-			if l == len(instance.PropertyVisitors) {
-				return errors.New("PropertyVisitor not found")
-			}
-		}
-
-		for k := 0; k < len(instance.Datas.Properties); k++ {
-			name := instance.Datas.Properties[k].PropertyName
-			l := 0
-			for l = 0; l < len(instance.PropertyVisitors); l++ {
-				if name == instance.PropertyVisitors[l].PropertyName {
-					instance.Datas.Properties[k].PVisitor = &instance.PropertyVisitors[l]
-					break
-				}
-			}
-			if l == len(instance.PropertyVisitors) {
-				return errors.New("PropertyVisitor not found")
-			}
+		} else if err != nil {
+			klog.Errorf("validate device profile failed: %v", err)
+			return err
 		}
 
 		devices[instance.ID] = new(globals.OPCUADev)


### PR DESCRIPTION
Extract the common function `ValidateProfileDeviceInstance` to validate device instance in parsing the configmap for three different protocols: `bluetooth`, `opcua`, `modbus`
Signed-off-by: gy95 <guoyao17@huawei.com>