### PR TITLE
fix make lint error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 SHELL := /bin/bash
 
+GOPATH?=$(shell go env GOPATH)
 curr_dir := $(patsubst %/,%,$(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
 rest_args := $(wordlist 2, $(words $(MAKECMDGOALS)), $(MAKECMDGOALS))
 $(eval $(rest_args):;@:)


### PR DESCRIPTION
run command `make lint`, error log is :
`/root/go/src/github.com/kubeedge/mappers-go/hack/lib/install.sh: line 62: GOPATH: unbound variable`
`make: *** [Makefile:55: lint] Error 1`

GOPATH should be defined in `Makefile` using `go env GOPATH`

Signed-off-by: gy95 <guoyao17@huawei.com>