### PR TITLE
fix twin data update publish

### DIFF
--- a/pkg/ble/device/twindata.go
+++ b/pkg/ble/device/twindata.go
@@ -82,7 +82,8 @@ func (td *TwinData) handlerPublish() (err error) {
 		}
 	}
 	if err = globals.MqttClient.Publish(td.Topic, payload); err != nil {
-		klog.Error(err)
+		klog.Errorf("Publish topic %v failed, err: %v", td.Topic, err)
+		return
 	}
 
 	klog.V(2).Infof("Update value: %s, topic: %s", td.Result, td.Topic)

--- a/pkg/modbus/device/device.go
+++ b/pkg/modbus/device/device.go
@@ -109,7 +109,7 @@ func onMessage(client mqtt.Client, message mqtt.Message) {
 		dev.Instance.Twins[i].Desired.Value = twinValue
 		var visitorConfig configmap.ModbusVisitorConfig
 		if err := json.Unmarshal([]byte(dev.Instance.Twins[i].PVisitor.VisitorConfig), &visitorConfig); err != nil {
-			klog.Error("Unmarshal visitor config failed: %v", err)
+			klog.Errorf("Unmarshal visitor config failed: %v", err)
 		}
 		setVisitor(&visitorConfig, &dev.Instance.Twins[i], dev.ModbusClient)
 	}

--- a/pkg/modbus/device/twindata.go
+++ b/pkg/modbus/device/twindata.go
@@ -61,7 +61,8 @@ func (td *TwinData) Run() {
 		}
 	}
 	if err = globals.MqttClient.Publish(td.Topic, payload); err != nil {
-		klog.Error(err)
+		klog.Errorf("Publish topic %v failed, err: %v", td.Topic, err)
+		return
 	}
 
 	klog.V(2).Infof("Update value: %s, topic: %s", strconv.Itoa(int(td.Results[0])), td.Topic)

--- a/pkg/opcua/device/twindata.go
+++ b/pkg/opcua/device/twindata.go
@@ -57,7 +57,8 @@ func (td *TwinData) Run() {
 		}
 	}
 	if err = globals.MqttClient.Publish(td.Topic, payload); err != nil {
-		klog.Error(err)
+		klog.Errorf("Publish topic %v failed, err: %v", td.Topic, err)
+		return
 	}
 
 	klog.V(2).Infof("Update value: %s, topic: %s", td.Result, td.Topic)


### PR DESCRIPTION
when device twin updated messages or data updated messages are published failed, function should return, just like contructing messages failed.

Signed-off-by: gy95 <guoyao17@huawei.com>