### PR TITLE
device instance structure should consistent with cloud definition

### DIFF
--- a/pkg/common/configmaptype.go
+++ b/pkg/common/configmaptype.go
@@ -70,7 +70,7 @@ type PropertyVisitor struct {
 	PropertyName  string `json:"propertyName,omitempty"`
 	ModelName     string `json:"modelName,omitempty"`
 	CollectCycle  int64  `json:"collectCycle"`
-	ReportCycle   int64  `json:"reportcycle,omitempty"`
+	ReportCycle   int64  `json:"reportCycle,omitempty"`
 	PProperty     Property
 	Protocol      string          `json:"protocol,omitempty"`
 	VisitorConfig json.RawMessage `json:"visitorConfig"`
@@ -79,7 +79,7 @@ type PropertyVisitor struct {
 // Data is data structure for the message that only be subscribed in edge node internal.
 type Data struct {
 	Properties []DataProperty `json:"dataProperties,omitempty"`
-	Topic      string         `json:"datatopic,omitempty"`
+	Topic      string         `json:"dataTopic,omitempty"`
 }
 
 // DataProperty is data property.

--- a/pkg/modbus/device/device.go
+++ b/pkg/modbus/device/device.go
@@ -109,7 +109,7 @@ func onMessage(client mqtt.Client, message mqtt.Message) {
 		dev.Instance.Twins[i].Desired.Value = twinValue
 		var visitorConfig configmap.ModbusVisitorConfig
 		if err := json.Unmarshal([]byte(dev.Instance.Twins[i].PVisitor.VisitorConfig), &visitorConfig); err != nil {
-			klog.Error("Unmarshal visitor config failed: %v", err)
+			klog.Errorf("Unmarshal visitor config failed: %v", err)
 		}
 		setVisitor(&visitorConfig, &dev.Instance.Twins[i], dev.ModbusClient)
 	}


### PR DESCRIPTION
mapper `DeviceInstance` structure should be the same as cloud deviceprofile `DeviceInstance` structure

Signed-off-by: gy95 <guoyao17@huawei.com>