### PR TITLE
fix modbus mqtt config verification bug

### DIFF
--- a/pkg/modbus/config.go
+++ b/pkg/modbus/config.go
@@ -77,7 +77,7 @@ func (c *Config) parseFlags() error {
 	pflag.StringVar(&c.Mqtt.PrivateKey, "mqtt-priviatekey", c.Mqtt.PrivateKey, "private key file path")
 	pflag.Parse()
 
-	if c.Mqtt.Cert == "" || c.Mqtt.PrivateKey == "" {
+	if (c.Mqtt.Cert != "" && c.Mqtt.PrivateKey == "") || (c.Mqtt.Cert == "" && c.Mqtt.PrivateKey != "") {
 		return ErrConfigCert
 	}
 	return nil

--- a/pkg/modbus/device/device.go
+++ b/pkg/modbus/device/device.go
@@ -109,7 +109,7 @@ func onMessage(client mqtt.Client, message mqtt.Message) {
 		dev.Instance.Twins[i].Desired.Value = twinValue
 		var visitorConfig configmap.ModbusVisitorConfig
 		if err := json.Unmarshal([]byte(dev.Instance.Twins[i].PVisitor.VisitorConfig), &visitorConfig); err != nil {
-			klog.Error("Unmarshal visitor config failed: %v", err)
+			klog.Errorf("Unmarshal visitor config failed: %v", err)
 		}
 		setVisitor(&visitorConfig, &dev.Instance.Twins[i], dev.ModbusClient)
 	}


### PR DESCRIPTION
modify modbus mqtt configuration verification rules: both fields `PrivateKey` and `Cert` need to be not-empty or empty

Signed-off-by: gy95 <guoyao17@huawei.com>