### PR TITLE
unify mqtt configuration to common

### DIFF
--- a/pkg/ble/config.go
+++ b/pkg/ble/config.go
@@ -23,21 +23,14 @@ import (
 	"github.com/spf13/pflag"
 	"gopkg.in/yaml.v2"
 	"k8s.io/klog/v2"
+
+	"github.com/kubeedge/mappers-go/pkg/common"
 )
 
 // Config is the ble mapper configuration.
 type Config struct {
-	Mqtt      Mqtt   `yaml:"mqtt,omitempty"`
-	Configmap string `yaml:"configmap"`
-}
-
-// Mqtt is the Mqtt configuration.
-type Mqtt struct {
-	ServerAddress string `yaml:"server,omitempty"`
-	Username      string `yaml:"username,omitempty"`
-	Password      string `yaml:"password,omitempty"`
-	Cert          string `yaml:"certification,omitempty"`
-	PrivateKey    string `yaml:"privatekey,omitempty"`
+	Mqtt      common.Mqtt `yaml:"mqtt,omitempty"`
+	Configmap string      `yaml:"configmap"`
 }
 
 // ErrConfigCert error of certification configuration.
@@ -70,12 +63,8 @@ func (c *Config) Parse() error {
 
 // parseFlags parse flags. Certification and Private key must be provided at the same time.
 func (c *Config) parseFlags() error {
-	pflag.StringVar(&c.Mqtt.ServerAddress, "mqtt-address", c.Mqtt.ServerAddress, "MQTT broker address")
-	pflag.StringVar(&c.Mqtt.Username, "mqtt-username", c.Mqtt.Username, "username")
-	pflag.StringVar(&c.Mqtt.Password, "mqtt-password", c.Mqtt.Password, "password")
-	pflag.StringVar(&c.Mqtt.Cert, "mqtt-certification", c.Mqtt.Cert, "certification file path")
-	pflag.StringVar(&c.Mqtt.PrivateKey, "mqtt-priviatekey", c.Mqtt.PrivateKey, "private key file path")
-	pflag.Parse()
+	common.ParseMqttConfig(&c.Mqtt)
+
 	if (c.Mqtt.Cert != "" && c.Mqtt.PrivateKey == "") ||
 		(c.Mqtt.Cert == "" && c.Mqtt.PrivateKey != "") {
 		return ErrConfigCert

--- a/pkg/common/event.go
+++ b/pkg/common/event.go
@@ -19,6 +19,7 @@ package common
 import (
 	"crypto/tls"
 	"encoding/json"
+	"github.com/spf13/pflag"
 	"regexp"
 	"time"
 
@@ -43,6 +44,24 @@ type MqttClient struct {
 	Cert       string
 	PrivateKey string
 	Client     mqtt.Client
+}
+
+// Mqtt is the Mqtt configuration.
+type Mqtt struct {
+	ServerAddress string `yaml:"server,omitempty"`
+	Username      string `yaml:"username,omitempty"`
+	Password      string `yaml:"password,omitempty"`
+	Cert          string `yaml:"certification,omitempty"`
+	PrivateKey    string `yaml:"privatekey,omitempty"`
+}
+
+func ParseMqttConfig(mqtt *Mqtt) {
+	pflag.StringVar(&mqtt.ServerAddress, "mqtt-address", mqtt.ServerAddress, "MQTT broker address")
+	pflag.StringVar(&mqtt.Username, "mqtt-username", mqtt.Username, "username")
+	pflag.StringVar(&mqtt.Password, "mqtt-password", mqtt.Password, "password")
+	pflag.StringVar(&mqtt.Cert, "mqtt-certification", mqtt.Cert, "certification file path")
+	pflag.StringVar(&mqtt.PrivateKey, "mqtt-priviatekey", mqtt.PrivateKey, "private key file path")
+	pflag.Parse()
 }
 
 // newTLSConfig new TLS configuration.

--- a/pkg/modbus/config.go
+++ b/pkg/modbus/config.go
@@ -23,21 +23,14 @@ import (
 	"github.com/spf13/pflag"
 	"gopkg.in/yaml.v2"
 	"k8s.io/klog/v2"
+
+	"github.com/kubeedge/mappers-go/pkg/common"
 )
 
 // Config is the modbus mapper configuration.
 type Config struct {
-	Mqtt      Mqtt   `yaml:"mqtt,omitempty"`
-	Configmap string `yaml:"configmap"`
-}
-
-// Mqtt is the Mqtt configuration.
-type Mqtt struct {
-	ServerAddress string `yaml:"server,omitempty"`
-	Username      string `yaml:"username,omitempty"`
-	Password      string `yaml:"password,omitempty"`
-	Cert          string `yaml:"certification,omitempty"`
-	PrivateKey    string `yaml:"privatekey,omitempty"`
+	Mqtt      common.Mqtt `yaml:"mqtt,omitempty"`
+	Configmap string      `yaml:"configmap"`
 }
 
 // ErrConfigCert error of certification configuration.
@@ -70,12 +63,7 @@ func (c *Config) Parse() error {
 
 // parseFlags parse flags. Certification and Private key must be provided at the same time.
 func (c *Config) parseFlags() error {
-	pflag.StringVar(&c.Mqtt.ServerAddress, "mqtt-address", c.Mqtt.ServerAddress, "MQTT broker address")
-	pflag.StringVar(&c.Mqtt.Username, "mqtt-username", c.Mqtt.Username, "username")
-	pflag.StringVar(&c.Mqtt.Password, "mqtt-password", c.Mqtt.Password, "password")
-	pflag.StringVar(&c.Mqtt.Cert, "mqtt-certification", c.Mqtt.Cert, "certification file path")
-	pflag.StringVar(&c.Mqtt.PrivateKey, "mqtt-priviatekey", c.Mqtt.PrivateKey, "private key file path")
-	pflag.Parse()
+	common.ParseMqttConfig(&c.Mqtt)
 
 	if c.Mqtt.Cert == "" || c.Mqtt.PrivateKey == "" {
 		return ErrConfigCert

--- a/pkg/modbus/device/device.go
+++ b/pkg/modbus/device/device.go
@@ -109,7 +109,7 @@ func onMessage(client mqtt.Client, message mqtt.Message) {
 		dev.Instance.Twins[i].Desired.Value = twinValue
 		var visitorConfig configmap.ModbusVisitorConfig
 		if err := json.Unmarshal([]byte(dev.Instance.Twins[i].PVisitor.VisitorConfig), &visitorConfig); err != nil {
-			klog.Error("Unmarshal visitor config failed: %v", err)
+			klog.Errorf("Unmarshal visitor config failed: %v", err)
 		}
 		setVisitor(&visitorConfig, &dev.Instance.Twins[i], dev.ModbusClient)
 	}

--- a/pkg/opcua/config.go
+++ b/pkg/opcua/config.go
@@ -23,21 +23,14 @@ import (
 	"github.com/spf13/pflag"
 	"gopkg.in/yaml.v2"
 	"k8s.io/klog/v2"
+
+	"github.com/kubeedge/mappers-go/pkg/common"
 )
 
 // Config is the modbus mapper configuration.
 type Config struct {
-	Mqtt      Mqtt   `yaml:"mqtt,omitempty"`
-	Configmap string `yaml:"configmap"`
-}
-
-// Mqtt is the Mqtt configuration.
-type Mqtt struct {
-	ServerAddress  string `yaml:"server,omitempty"`
-	UserName       string `yaml:"username,omitempty"`
-	Password       string `yaml:"password,omitempty"`
-	CertFile       string `yaml:"certification,omitempty"`
-	PrivateKeyFile string `yaml:"privatekey,omitempty"`
+	Mqtt      common.Mqtt `yaml:"mqtt,omitempty"`
+	Configmap string      `yaml:"configmap"`
 }
 
 // ErrConfigCert error of certification configuration.
@@ -70,16 +63,10 @@ func (c *Config) Parse() error {
 
 // parseFlags parse flags. Certification and Private key must be provided at the same time.
 func (c *Config) parseFlags() error {
-	pflag.StringVar(&c.Mqtt.ServerAddress, "mqtt-address", c.Mqtt.ServerAddress, "MQTT broker address")
-	pflag.StringVar(&c.Mqtt.UserName, "mqtt-username", c.Mqtt.UserName, "username")
-	pflag.StringVar(&c.Mqtt.Password, "mqtt-password", c.Mqtt.Password, "password")
-	pflag.StringVar(&c.Mqtt.CertFile, "mqtt-certification", c.Mqtt.CertFile, "certification file path")
-	pflag.StringVar(&c.Mqtt.PrivateKeyFile, "mqtt-priviatekey", c.Mqtt.PrivateKeyFile, "private key file path")
+	common.ParseMqttConfig(&c.Mqtt)
 
-	pflag.Parse()
-
-	if (c.Mqtt.CertFile != "" && c.Mqtt.PrivateKeyFile == "") ||
-		(c.Mqtt.CertFile == "" && c.Mqtt.PrivateKeyFile != "") {
+	if (c.Mqtt.Cert != "" && c.Mqtt.PrivateKey == "") ||
+		(c.Mqtt.Cert == "" && c.Mqtt.PrivateKey != "") {
 		return ErrConfigCert
 	}
 

--- a/pkg/opcua/main.go
+++ b/pkg/opcua/main.go
@@ -40,10 +40,10 @@ func main() {
 	klog.V(4).Info(config.Configmap)
 
 	globals.MqttClient = mappercommon.MqttClient{IP: config.Mqtt.ServerAddress,
-		User:       config.Mqtt.UserName,
+		User:       config.Mqtt.Username,
 		Passwd:     config.Mqtt.Password,
-		Cert:       config.Mqtt.CertFile,
-		PrivateKey: config.Mqtt.PrivateKeyFile}
+		Cert:       config.Mqtt.Cert,
+		PrivateKey: config.Mqtt.PrivateKey}
 	if err = globals.MqttClient.Connect(); err != nil {
 		klog.Fatal(err)
 		os.Exit(1)


### PR DESCRIPTION
mapper config.yaml all have the same mqtt configuration, so we can use the common mqtt configuration

Signed-off-by: gy95 <guoyao17@huawei.com>