### PR TITLE
fix/mapper: make Parse recognize customizedProtocol correctly

### DIFF
--- a/_template/mapper/configmap/parse.go
+++ b/_template/mapper/configmap/parse.go
@@ -23,8 +23,8 @@ import (
 
 	"k8s.io/klog/v2"
 
-	"github.com/kubeedge/mappers-go/mappers/common"
 	"github.com/kubeedge/mappers-go/mappers/Template/globals"
+	"github.com/kubeedge/mappers-go/mappers/common"
 )
 
 // Parse parse the configmap.
@@ -57,8 +57,21 @@ func Parse(path string,
 			return err
 		}
 
-		if instance.PProtocol.Protocol != "Template" {
+		if instance.PProtocol.Protocol != "customized-protocol" {
 			continue
+		} else {
+			cprotocol := struct {
+				ProtocolName string `json:"protocolName"`
+				ConfigData   json.RawMessage
+			}{}
+			err = json.Unmarshal(instance.PProtocol.ProtocolConfigs, &cprotocol)
+			if err != nil {
+				klog.Error("customized-protocol unmarshal error:", err)
+				continue
+			}
+			if cprotocol.ProtocolName != "Template" {
+				continue
+			}
 		}
 
 		for k := 0; k < len(instance.PropertyVisitors); k++ {


### PR DESCRIPTION
modify _template/mapper/configmap/parse.go, validate instance.PProtocol.ProtocolConfigs.ProtocolName

Fixes #74

Signed-off-by: jsparter <1084237763@qq.com>