### PR TITLE
workflow go version 1.17

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16.x
+          go-version: 1.17.x
 
       - uses: actions/cache@v2
         with:
@@ -47,7 +47,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16.x
+          go-version: 1.17.x
 
       - uses: actions/cache@v2
         with:
@@ -75,7 +75,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16.x
+          go-version: 1.17.x
 
       - uses: actions/cache@v2
         with:


### PR DESCRIPTION
Signed-off-by: chenlin.liu <chenlin.liu@daocloud.io>

update workflow Install Go version step to 1.17.x