### PR TITLE
Update client.go

### DIFF
--- a/mappers/opcua/driver/client.go
+++ b/mappers/opcua/driver/client.go
@@ -109,7 +109,7 @@ func valueToString(v *ua.Variant) string {
 	case ua.TypeIDByteString:
 		return string(v.ByteString())
 	case ua.TypeIDFloat, ua.TypeIDDouble:
-		return strconv.FormatFloat(v.Float(), 'E', -1, 32)
+		return strconv.FormatFloat(v.Float(), 'f', -1, 64)
 	default:
 		return ""
 	}


### PR DESCRIPTION
strconv.FormatFloat(v.Float(), 'E', -1, 32)
will convert float to some  6E+01  string. 
It can not be recongized by  edgecore. this value won't be updated to cloudcore. 
we should convert float to just like  61.25 string. 

Waste a lot of my time.

reference:   
https://qa.1r1g.com/sf/ask/2369649831/