### PR TITLE
Modify data update strategy

### DIFF
--- a/mapper-sdk-go/internal/mqttadapter/subscribe.go
+++ b/mapper-sdk-go/internal/mqttadapter/subscribe.go
@@ -42,11 +42,7 @@ func SyncInfo(dic *di.Container, message mqtt.Message) {
 		}
 		if i == len(deviceInstances[instanceID].Twins) {
 			continue
-		}
-		// Desired value is not changed.
-		if deviceInstances[instanceID].Twins[i].Desired.Value == twinValue {
-			continue
-		}
+		}	
 		if len(twinValue) > 30{
 			klog.V(4).Infof("Set %s:%s value to %s......", instanceID, twinName, twinValue[:30])
 		}else{


### PR DESCRIPTION
When the device's desire value is inconsistent with the report value, edgecore will re-deliver the desire value. This judgment will cause the desire value to fail to be delivered, because the desire value saved by the mapper has not changed.