### PR TITLE
DMI bugfix modbus reconnect

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -39,6 +39,7 @@ type Config struct {
 	GrpcServer GRPCServer `yaml:"grpc_server"`
 	Common     Common     `yaml:"common"`
 	DevInit    DevInit    `yaml:"dev_init"`
+	LogLevel   string     `yaml:"log_level"`
 }
 
 type GRPCServer struct {
@@ -63,9 +64,13 @@ type DevInit struct {
 func (c *Config) Parse() error {
 	var level klog.Level
 	var loglevel string
-	var configFile string
 
 	pflag.StringVar(&loglevel, "v", "1", "log level")
+	if err := level.Set(loglevel); err != nil {
+		return err
+	}
+
+	var configFile string
 	pflag.StringVar(&configFile, "config-file", defaultConfigFile, "Config file name")
 
 	cf, err := ioutil.ReadFile(configFile)
@@ -75,8 +80,10 @@ func (c *Config) Parse() error {
 	if err = yaml.Unmarshal(cf, c); err != nil {
 		return err
 	}
-	if err = level.Set(loglevel); err != nil {
-		return err
+	if len(c.LogLevel) != 0 && c.LogLevel != "0" {
+		if serr := level.Set(c.LogLevel); serr != nil {
+			return serr
+		}
 	}
 
 	switch c.DevInit.Mode {

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -10,3 +10,4 @@ common:
 dev_init:
   mode: register #register/configmap
   configmap: /opt/kubeedge/deviceProfile.json
+log_level: 1

--- a/mappers/modbus-dmi/config.yaml
+++ b/mappers/modbus-dmi/config.yaml
@@ -9,3 +9,4 @@ common:
   edgecore_sock: /etc/kubeedge/dmi.sock
 dev_init:
   mode: register #register/configmap
+log_level: 1

--- a/mappers/modbus-dmi/device/device.go
+++ b/mappers/modbus-dmi/device/device.go
@@ -62,7 +62,7 @@ func setVisitor(visitorConfig *modbus.ModbusVisitorConfig, twin *common.Twin, cl
 			klog.Errorf("twin %s Convert error: %v", value, err)
 			return
 		}
-		_, err = client.Set(visitorConfig.Register, visitorConfig.Offset, uint16(valueInt))
+		_, err = client.SetWithRetry(visitorConfig.Register, visitorConfig.Offset, uint16(valueInt), 2)
 		if err != nil {
 			klog.Errorf("Set visitor error: %v %v", err, visitorConfig)
 			return
@@ -73,7 +73,7 @@ func setVisitor(visitorConfig *modbus.ModbusVisitorConfig, twin *common.Twin, cl
 			klog.Errorf("twin %s Convert error: %v", value, err)
 			return
 		}
-		_, err = client.SetString(visitorConfig.Register, visitorConfig.Offset, visitorConfig.Limit, string(ConvertFloat32ToBytes(float32(valueFloat))))
+		_, err = client.SetStringWithRetry(visitorConfig.Register, visitorConfig.Offset, visitorConfig.Limit, string(ConvertFloat32ToBytes(float32(valueFloat))), 2)
 		if err != nil {
 			klog.Errorf("Set visitor error: %v %v", err, visitorConfig)
 			return
@@ -84,7 +84,7 @@ func setVisitor(visitorConfig *modbus.ModbusVisitorConfig, twin *common.Twin, cl
 			klog.Errorf("twin %s Convert error: %v", value, err)
 			return
 		}
-		_, err = client.SetString(visitorConfig.Register, visitorConfig.Offset, visitorConfig.Limit, string(ConvertFloat64ToBytes(valueDouble)))
+		_, err = client.SetStringWithRetry(visitorConfig.Register, visitorConfig.Offset, visitorConfig.Limit, string(ConvertFloat64ToBytes(valueDouble)), 2)
 		if err != nil {
 			klog.Errorf("Set visitor error: %v %v", err, visitorConfig)
 			return
@@ -99,13 +99,13 @@ func setVisitor(visitorConfig *modbus.ModbusVisitorConfig, twin *common.Twin, cl
 		if valueBool {
 			valueSet = 0xFF00
 		}
-		_, err = client.Set(visitorConfig.Register, visitorConfig.Offset, valueSet)
+		_, err = client.SetWithRetry(visitorConfig.Register, visitorConfig.Offset, valueSet, 2)
 		if err != nil {
 			klog.Errorf("Set visitor error: %v %v", err, visitorConfig)
 			return
 		}
 	case "string":
-		_, err := client.SetString(visitorConfig.Register, visitorConfig.Offset, visitorConfig.Limit, value)
+		_, err := client.SetStringWithRetry(visitorConfig.Register, visitorConfig.Offset, visitorConfig.Limit, value, 2)
 		if err != nil {
 			klog.Errorf("Set visitor error: %v %v", err, visitorConfig)
 			return

--- a/mappers/modbus-dmi/device/device.go
+++ b/mappers/modbus-dmi/device/device.go
@@ -308,7 +308,8 @@ func getTwinData(deviceID string, twin common.Twin, client *modbus.ModbusClient)
 		VisitorConfig: &visitorConfig,
 		Topic:         fmt.Sprintf(common.TopicTwinUpdate, deviceID),
 	}
-	return td.GetPayload()
+	payload, _, err := td.GetPayload()
+	return payload, err
 }
 
 func (d *DevPanel) GetDevice(deviceID string) (interface{}, error) {

--- a/mappers/modbus-dmi/device/twindata.go
+++ b/mappers/modbus-dmi/device/twindata.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/klog/v2"
 
 	dmiapi "github.com/kubeedge/kubeedge/pkg/apis/dmi/v1alpha1"
+
 	"github.com/kubeedge/mappers-go/pkg/common"
 	"github.com/kubeedge/mappers-go/pkg/driver/modbus"
 	"github.com/kubeedge/mappers-go/pkg/util/grpcclient"
@@ -36,6 +37,7 @@ import (
 
 // TwinData is the timer structure for getting twin/data.
 type TwinData struct {
+	DeviceID      string
 	DeviceName    string
 	Client        *modbus.ModbusClient
 	Name          string
@@ -119,7 +121,7 @@ func TransferData(isRegisterSwap bool, isSwap bool,
 		data := string(value)
 		return data, nil
 	default:
-		return "", errors.New("Data type is not support")
+		return "", errors.New("data type is not support")
 	}
 }
 
@@ -168,7 +170,7 @@ func (td *TwinData) Run() {
 	twins := parse.ConvMsgTwinToGrpc(msg.Twin)
 
 	var rdsr = &dmiapi.ReportDeviceStatusRequest{
-		DeviceName: td.DeviceName,
+		DeviceName: td.DeviceID,
 		ReportedDevice: &dmiapi.DeviceStatus{
 			Twins: twins,
 			State: "OK",

--- a/mappers/modbus-dmi/device/twindata.go
+++ b/mappers/modbus-dmi/device/twindata.go
@@ -170,7 +170,7 @@ func isSpecial(b byte) bool {
 func (td *TwinData) GetPayload() ([]byte, bool, error) {
 	var err error
 
-	td.Results, err = td.Client.Get(td.VisitorConfig.Register, td.VisitorConfig.Offset, uint16(td.VisitorConfig.Limit))
+	td.Results, err = td.Client.GetWithRetry(td.VisitorConfig.Register, td.VisitorConfig.Offset, uint16(td.VisitorConfig.Limit), 2)
 	if err != nil {
 		return nil, false, fmt.Errorf("get register failed: %v", err)
 	}

--- a/mappers/modbus-dmi/device/twindata.go
+++ b/mappers/modbus-dmi/device/twindata.go
@@ -114,16 +114,57 @@ func TransferData(isRegisterSwap bool, isSwap bool,
 		}
 		bits := binary.BigEndian.Uint32(value)
 		data := float64(math.Float32frombits(bits)) * scale
-		sData := strconv.FormatFloat(data, 'f', 6, 64)
+		sData := strconv.FormatFloat(data, 'f', 2, 64)
 		return sData, nil
 	case "boolean":
-		return strconv.FormatBool(value[0] == 1), nil
+		return strconv.FormatBool(value[0] == 0xFF), nil
 	case "string":
-		data := string(value)
+		for i, b := range value {
+			if !isUpper(b) && !isLowercase(b) && !isNumber(b) && !isSpecial(b) {
+				value[i] = ' '
+			}
+		}
+		data := strings.ReplaceAll(string(value), " ", "")
 		return data, nil
 	default:
 		return "", errors.New("data type is not support")
 	}
+}
+
+func isUpper(b byte) bool {
+	return 'A' <= b && b <= 'Z'
+}
+
+func isLowercase(b byte) bool {
+	return 'a' <= b && b <= 'z'
+}
+
+func isNumber(b byte) bool {
+	return '0' <= b && b <= '9'
+}
+
+func isSpecial(b byte) bool {
+	whiteList := map[byte]byte{
+		'/': '/',
+		'-': '-',
+		'_': '_',
+		'.': '.',
+		'%': '%',
+		'+': '+',
+		',': ',',
+		'=': '=',
+		'@': '@',
+		'#': '#',
+		':': ':',
+		'^': '^',
+		'~': '~',
+		'?': '?',
+		'&': '&',
+		'!': '!',
+		'*': '*',
+	}
+	_, ok := whiteList[b]
+	return ok
 }
 
 func (td *TwinData) GetPayload() ([]byte, bool, error) {

--- a/pkg/driver/modbus/client.go
+++ b/pkg/driver/modbus/client.go
@@ -23,8 +23,9 @@ import (
 
 	"k8s.io/klog/v2"
 
-	"github.com/kubeedge/mappers-go/pkg/common"
 	"github.com/sailorvii/modbus"
+
+	"github.com/kubeedge/mappers-go/pkg/common"
 )
 
 // ModbusTCP is the configurations of modbus TCP.

--- a/pkg/grpcserver/device.go
+++ b/pkg/grpcserver/device.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	dmiapi "github.com/kubeedge/kubeedge/pkg/apis/dmi/v1alpha1"
+
 	"github.com/kubeedge/mappers-go/pkg/common"
 	"github.com/kubeedge/mappers-go/pkg/driver/modbus"
 	"github.com/kubeedge/mappers-go/pkg/util/parse"
@@ -63,7 +64,7 @@ func (s *Server) RemoveDevice(ctx context.Context, request *dmiapi.RemoveDeviceR
 }
 
 func (s *Server) UpdateDevice(ctx context.Context, request *dmiapi.UpdateDeviceRequest) (*dmiapi.UpdateDeviceResponse, error) {
-	klog.V(2).Info("UpdateDevice")
+	klog.Info("UpdateDevice")
 	device := request.GetDevice()
 	if device == nil {
 		return nil, errors.New("device is nil")
@@ -78,7 +79,7 @@ func (s *Server) UpdateDevice(ctx context.Context, request *dmiapi.UpdateDeviceR
 		return nil, fmt.Errorf("parse device %s protocol failed, err: %s", device.Name, err)
 	}
 
-	klog.Infof("model: %+v", model)
+	klog.Infof("UpdateDevice model: %+v", model)
 	deviceInstance, err := parse.ParseDeviceFromGrpc(device, &model)
 	if err != nil {
 		return nil, fmt.Errorf("parse device %s instance failed, err: %s", device.Name, err)
@@ -86,6 +87,7 @@ func (s *Server) UpdateDevice(ctx context.Context, request *dmiapi.UpdateDeviceR
 	deviceInstance.PProtocol = protocol
 
 	s.devPanel.UpdateDev(&model, deviceInstance, &protocol)
+	klog.Infof("UpdateDevice success, device: %+v", deviceInstance)
 
 	return &dmiapi.UpdateDeviceResponse{}, nil
 }
@@ -107,6 +109,7 @@ func (s *Server) CreateDeviceModel(ctx context.Context, request *dmiapi.CreateDe
 }
 
 func (s *Server) UpdateDeviceModel(ctx context.Context, request *dmiapi.UpdateDeviceModelRequest) (*dmiapi.UpdateDeviceModelResponse, error) {
+	klog.Info("UpdateDeviceModel")
 	deviceModel := request.GetModel()
 	if deviceModel == nil {
 		return nil, errors.New("deviceModel is nil")
@@ -118,6 +121,7 @@ func (s *Server) UpdateDeviceModel(ctx context.Context, request *dmiapi.UpdateDe
 	model := parse.ParseDeviceModelFromGrpc(deviceModel)
 
 	s.devPanel.UpdateModel(&model)
+	klog.Infof("UpdateDeviceModel model: %+v", model)
 
 	return &dmiapi.UpdateDeviceModelResponse{}, nil
 }

--- a/pkg/util/parse/grpc.go
+++ b/pkg/util/parse/grpc.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/kubeedge/kubeedge/cloud/pkg/devicecontroller/constants"
 	dmiapi "github.com/kubeedge/kubeedge/pkg/apis/dmi/v1alpha1"
+
 	"github.com/kubeedge/mappers-go/pkg/common"
 )
 
@@ -245,6 +246,7 @@ func ParseDeviceModelFromGrpc(model *dmiapi.DeviceModel) common.DeviceModel {
 			Name:        property.GetName(),
 			Description: property.GetDescription(),
 		}
+		klog.V(2).Infof("Parse device model property from grpc, name %s, type %+v", property.GetName(), property.Type)
 		if property.Type.GetString_() != nil {
 			p.DataType = "string"
 			p.AccessMode = property.Type.String_.GetAccessMode()

--- a/pkg/util/parse/parse.go
+++ b/pkg/util/parse/parse.go
@@ -139,6 +139,7 @@ func ParseByUsingRegister(cfg *config.Config,
 	if err != nil {
 		return err
 	}
+	klog.Infof("RegisterMapper success, deviceList %+v, deviceModelList %+v", deviceList, deviceModelList)
 
 	if len(deviceList) == 0 || len(deviceModelList) == 0 {
 		return ErrEmptyData
@@ -162,7 +163,7 @@ func ParseByUsingRegister(cfg *config.Config,
 		instance.PProtocol = protocol
 		devices[instance.ID] = new(common.DeviceInstance)
 		devices[instance.ID] = instance
-		klog.V(4).Info("Instance: ", instance.ID)
+		klog.Info("Instance: ", instance.ID)
 		dms[instance.Model] = modelMap[instance.Model]
 		protocols[instance.ProtocolName] = protocol
 	}

--- a/pkg/util/parse/type.go
+++ b/pkg/util/parse/type.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kubeedge/kubeedge/cloud/pkg/devicecontroller/constants"
 	"github.com/kubeedge/kubeedge/pkg/apis/devices/v1alpha2"
 	dmiapi "github.com/kubeedge/kubeedge/pkg/apis/dmi/v1alpha1"
+
 	"github.com/kubeedge/mappers-go/pkg/common"
 )
 
@@ -336,12 +337,6 @@ func ConvMsgTwinToGrpc(msgTwin map[string]*common.MsgTwin) []*dmiapi.Twin {
 	for name, twin := range msgTwin {
 		twinData := &dmiapi.Twin{
 			PropertyName: name,
-			Desired: &dmiapi.TwinProperty{
-				Value: *twin.Expected.Value,
-				Metadata: map[string]string{
-					"type":      twin.Metadata.Type,
-					"timestamp": twin.Expected.Metadata.Timestamp,
-				}},
 			Reported: &dmiapi.TwinProperty{
 				Value: *twin.Actual.Value,
 				Metadata: map[string]string{


### PR DESCRIPTION
fix the bug proposed in this issue: https://github.com/kubeedge/mappers-go/issues/98
add the `Reconnect()` function and reconnect to the device when the mapper fails to write data.
update the `Get()`, `Set()` and `SetString` function to `GetWithRetry()`, `SetWithRetry()` and `SetStringWithRetry()` function.