### PR TITLE
add lint.sh and update the version of golangci-lint from 1.39.0 to 1.42.0

### DIFF
--- a/hack/lib/install.sh
+++ b/hack/lib/install.sh
@@ -50,19 +50,32 @@ function check_kind {
 # check if golangci-lint installed
 function check_golangci-lint {
   echo "checking golangci-lint"
+  GOPATH="${GOPATH:-$(go env GOPATH)}"
+  export PATH=$PATH:$GOPATH/bin
+  expectedVersion="1.42.0"
   command -v golangci-lint >/dev/null 2>&1
   if [[ $? -ne 0 ]]; then
-    echo "installing golangci-lint ."
-    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.39.0
+    install_golangci
+  else
+     version=$(golangci-lint version)
+        if [[ $version =~ $expectedVersion ]]; then
+          echo -n "found golangci-lint, version: " && golangci-lint version
+        else
+          echo "golangci-lint version not matched, now version is $version, begin to install new version $expectedVersion"
+          install_golangci-lint
+        fi
+  fi
+}
+
+function install_golangci-lint {
+  echo "installing golangci-lint ."
+    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ${GOPATH}/bin v1.42.0
     if [[ $? -ne 0 ]]; then
       echo "golangci-lint installed failed, exiting."
       exit 1
     fi
 
     export PATH=$PATH:$GOPATH/bin
-  else
-    echo -n "found golangci-lint, version: " && golangci-lint version
-  fi
 }
 
 verify_go_version(){

--- a/mappers/ble/hack/make-rules/mapper.sh
+++ b/mappers/ble/hack/make-rules/mapper.sh
@@ -7,6 +7,7 @@ set -o pipefail
 CURR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
 ROOT_DIR="$(cd "${CURR_DIR}/../.." && pwd -P)"
 source "${ROOT_DIR}/hack/lib/init.sh"
+source "${ROOT_DIR}/hack/lib/install.sh"
 
 mkdir -p "${CURR_DIR}/bin"
 mkdir -p "${CURR_DIR}/dist"
@@ -35,6 +36,9 @@ function mod() {
 function lint() {
   [[ "${2:-}" != "only" ]] && mod "$@"
   local mapper="${1}"
+
+  echo "check_golangci-lint..."
+  check_golangci-lint
 
   echo "fmt and linting mapper ${mapper}..."
 

--- a/mappers/gige/hack/make-rules/mapper.sh
+++ b/mappers/gige/hack/make-rules/mapper.sh
@@ -7,6 +7,7 @@ set -o pipefail
 CURR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
 ROOT_DIR="$(cd "${CURR_DIR}/../.." && pwd -P)"
 source "${ROOT_DIR}/hack/lib/init.sh"
+source "${ROOT_DIR}/hack/lib/install.sh"
 
 mkdir -p "${CURR_DIR}/bin"
 mkdir -p "${CURR_DIR}/dist"
@@ -35,6 +36,9 @@ function mod() {
 function lint() {
   [[ "${2:-}" != "only" ]] && mod "$@"
   local mapper="${1}"
+
+  echo "check_golangci-lint..."
+  check_golangci-lint
 
   echo "fmt and linting mapper ${mapper}..."
 

--- a/mappers/modbus-dmi/hack/make-rules/mapper.sh
+++ b/mappers/modbus-dmi/hack/make-rules/mapper.sh
@@ -7,6 +7,7 @@ set -o pipefail
 CURR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
 ROOT_DIR="$(cd "${CURR_DIR}/../.." && pwd -P)"
 source "${ROOT_DIR}/hack/lib/init.sh"
+source "${ROOT_DIR}/hack/lib/install.sh"
 
 mkdir -p "${CURR_DIR}/bin"
 mkdir -p "${CURR_DIR}/dist"
@@ -35,6 +36,9 @@ function mod() {
 function lint() {
   [[ "${2:-}" != "only" ]] && mod "$@"
   local mapper="${1}"
+
+  echo "check_golangci-lint..."
+  check_golangci-lint
 
   echo "fmt and linting mapper ${mapper}..."
 

--- a/mappers/modbus/hack/make-rules/mapper.sh
+++ b/mappers/modbus/hack/make-rules/mapper.sh
@@ -7,6 +7,7 @@ set -o pipefail
 CURR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
 ROOT_DIR="$(cd "${CURR_DIR}/../.." && pwd -P)"
 source "${ROOT_DIR}/hack/lib/init.sh"
+source "${ROOT_DIR}/hack/lib/install.sh"
 
 mkdir -p "${CURR_DIR}/bin"
 mkdir -p "${CURR_DIR}/dist"
@@ -35,6 +36,9 @@ function mod() {
 function lint() {
   [[ "${2:-}" != "only" ]] && mod "$@"
   local mapper="${1}"
+
+  echo "check_golangci-lint..."
+  check_golangci-lint
 
   echo "fmt and linting mapper ${mapper}..."
 

--- a/mappers/onvif/hack/make-rules/mapper.sh
+++ b/mappers/onvif/hack/make-rules/mapper.sh
@@ -7,6 +7,7 @@ set -o pipefail
 CURR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
 ROOT_DIR="$(cd "${CURR_DIR}/../.." && pwd -P)"
 source "${ROOT_DIR}/hack/lib/init.sh"
+source "${ROOT_DIR}/hack/lib/install.sh"
 
 mkdir -p "${CURR_DIR}/bin"
 mkdir -p "${CURR_DIR}/dist"
@@ -35,6 +36,9 @@ function mod() {
 function lint() {
   [[ "${2:-}" != "only" ]] && mod "$@"
   local mapper="${1}"
+
+  echo "check_golangci-lint..."
+  check_golangci-lint
 
   echo "fmt and linting mapper ${mapper}..."
 

--- a/mappers/opcua/hack/make-rules/mapper.sh
+++ b/mappers/opcua/hack/make-rules/mapper.sh
@@ -7,6 +7,7 @@ set -o pipefail
 CURR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
 ROOT_DIR="$(cd "${CURR_DIR}/../.." && pwd -P)"
 source "${ROOT_DIR}/hack/lib/init.sh"
+source "${ROOT_DIR}/hack/lib/install.sh"
 
 mkdir -p "${CURR_DIR}/bin"
 mkdir -p "${CURR_DIR}/dist"
@@ -35,6 +36,9 @@ function mod() {
 function lint() {
   [[ "${2:-}" != "only" ]] && mod "$@"
   local mapper="${1}"
+
+  echo "check_golangci-lint..."
+  check_golangci-lint
 
   echo "fmt and linting mapper ${mapper}..."
 

--- a/mappers/virtualdevice-sdk/hack/make-rules/mapper.sh
+++ b/mappers/virtualdevice-sdk/hack/make-rules/mapper.sh
@@ -7,6 +7,7 @@ set -o pipefail
 CURR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
 ROOT_DIR="$(cd "${CURR_DIR}/../.." && pwd -P)"
 source "${ROOT_DIR}/hack/lib/init.sh"
+source "${ROOT_DIR}/hack/lib/install.sh"
 
 mkdir -p "${CURR_DIR}/bin"
 mkdir -p "${CURR_DIR}/dist"
@@ -35,6 +36,9 @@ function mod() {
 function lint() {
   [[ "${2:-}" != "only" ]] && mod "$@"
   local mapper="${1}"
+
+  echo "check_golangci-lint..."
+  check_golangci-lint
 
   echo "fmt and linting mapper ${mapper}..."
 


### PR DESCRIPTION
update the version of golangci-lint from 1.39.0 to 1.42.0 and add the installation of golangci-lint to all the current mappers.
use command 
```
make all lint
or
make mapper ble lint
```
to install golangci-lint and lint the code of mapper.