### PR TITLE
dmi mapper bugfix

### DIFF
--- a/build/crd-samples/devices/modbus-device-model.yaml
+++ b/build/crd-samples/devices/modbus-device-model.yaml
@@ -18,4 +18,4 @@ spec:
       int:
         accessMode: ReadWrite
         defaultValue: 1
-
+ protocol: modbus

--- a/build/crd-samples/devices/modbusrtu-device-instance.yaml
+++ b/build/crd-samples/devices/modbusrtu-device-instance.yaml
@@ -30,6 +30,8 @@ spec:
         - test
   propertyVisitors:
     - propertyName: temperature
+      collectCycle: 1000
+      reportCycle: 1000
       modbus:
         register: CoilRegister
         offset: 2

--- a/build/crd-samples/devices/modbustcp-device-instance.yaml
+++ b/build/crd-samples/devices/modbustcp-device-instance.yaml
@@ -44,13 +44,14 @@ spec:
 status:
   twins:
     - propertyName: temperature-enable
-      reported:
-        metadata:
-          timestamp: '1550049403598'
-          type: integer
-        value: "0"
       desired:
         metadata:
           timestamp: '1550049403598'
-          type: integer
-        value: "0"
+          type: int
+        value: "1"
+    - propertyName: temperature
+      desired:
+        metadata:
+          timestamp: '1550049403598'
+          type: int
+        value: "28"

--- a/mappers/modbus-dmi/device/device.go
+++ b/mappers/modbus-dmi/device/device.go
@@ -52,7 +52,7 @@ func setVisitor(visitorConfig *modbus.ModbusVisitorConfig, twin *common.Twin, cl
 	}
 
 	klog.V(2).Infof("Convert type: %s, value: %s ", twin.PVisitor.PProperty.DataType, twin.Desired.Value)
-	value, err := common.Convert(twin.PVisitor.PProperty.DataType, twin.Desired.Value)
+	value, err := common.Convert(twin.Desired.Metadatas.Type, twin.Desired.Value)
 	if err != nil {
 		klog.Errorf("Convert error: %v", err)
 		return
@@ -127,7 +127,7 @@ func initTwin(ctx context.Context, dev *modbus.ModbusDev) {
 			VisitorConfig: &visitorConfig,
 			Topic:         fmt.Sprintf(common.TopicTwinUpdate, dev.Instance.ID),
 			DeviceName:    dev.Instance.Name}
-		collectCycle := time.Duration(dev.Instance.Twins[i].PVisitor.CollectCycle)
+		collectCycle := time.Duration(dev.Instance.Twins[i].PVisitor.CollectCycle) * time.Millisecond
 		// If the collect cycle is not set, set it to 1 second.
 		if collectCycle == 0 {
 			collectCycle = 1 * time.Second

--- a/mappers/modbus-dmi/device/twindata.go
+++ b/mappers/modbus-dmi/device/twindata.go
@@ -119,7 +119,7 @@ func TransferData(isRegisterSwap bool, isSwap bool,
 		data := string(value)
 		return data, nil
 	default:
-		return "", errors.New("Data type is not support")
+		return "", errors.New("Data type is not support: " + dataType)
 	}
 }
 
@@ -177,4 +177,5 @@ func (td *TwinData) Run() {
 	if err := grpcclient.ReportDeviceStatus(rdsr); err != nil {
 		klog.Errorf("fail to report device status of %s with err: %+v", rdsr.DeviceName, err)
 	}
+	klog.V(2).Infof("reported status: %s", td.DeviceName)
 }

--- a/pkg/common/event.go
+++ b/pkg/common/event.go
@@ -20,6 +20,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"regexp"
+	"strconv"
 	"time"
 
 	mqtt "github.com/eclipse/paho.mqtt.golang"
@@ -124,6 +125,7 @@ func CreateMessageTwinUpdate(name string, valueType string, value string) (msg [
 	updateMsg.Twin = map[string]*MsgTwin{}
 	updateMsg.Twin[name] = &MsgTwin{}
 	updateMsg.Twin[name].Actual = &TwinValue{Value: &value}
+	updateMsg.Twin[name].Actual.Metadata.Timestamp = strconv.FormatInt(getTimestamp(), 10)
 	updateMsg.Twin[name].Metadata = &TypeMetadata{Type: valueType}
 
 	msg, err = json.Marshal(updateMsg)

--- a/pkg/util/parse/type.go
+++ b/pkg/util/parse/type.go
@@ -336,12 +336,6 @@ func ConvMsgTwinToGrpc(msgTwin map[string]*common.MsgTwin) []*dmiapi.Twin {
 	for name, twin := range msgTwin {
 		twinData := &dmiapi.Twin{
 			PropertyName: name,
-			Desired: &dmiapi.TwinProperty{
-				Value: *twin.Expected.Value,
-				Metadata: map[string]string{
-					"type":      twin.Metadata.Type,
-					"timestamp": twin.Expected.Metadata.Timestamp,
-				}},
 			Reported: &dmiapi.TwinProperty{
 				Value: *twin.Actual.Value,
 				Metadata: map[string]string{


### PR DESCRIPTION
fix some bug of DMI mapper of modbus:

1. update samples device.yaml and device-model.yaml
2. fix device twin report Timestamp
3. fix device Desired data
4. collectCycle add Millisecond unit