### PR TITLE
init issue template in mappers-go

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,38 @@
+---
+name: Bug Report
+about: Report a bug encountered while operating KubeEdge
+labels: kind/bug
+
+---
+
+<!-- Please use this template while reporting a bug and provide as much info as possible. Thanks!-->
+**What happened**:
+
+**What you expected to happen**:
+
+**How to reproduce it (as minimally and precisely as possible)**:
+
+**Anything else we need to know?**:
+
+**Environment**:
+- Kubernetes version (use `kubectl version`):
+- KubeEdge version(e.g. `cloudcore --version` and `edgecore --version`):
+- <details><summary>Cloud nodes Environment:</summary>
+
+  - Hardware configuration (e.g. `lscpu`):
+  - OS (e.g. `cat /etc/os-release`):
+  - Kernel (e.g. `uname -a`):
+  - Go version (e.g. `go version`):
+  - Others:
+
+  </details>
+- <details><summary>Edge nodes Environment:</summary>
+
+  - edgecore version (e.g. `edgecore --version`):
+  - Hardware configuration (e.g. `lscpu`):
+  - OS (e.g. `cat /etc/os-release`):
+  - Kernel (e.g. `uname -a`):
+  - Go version (e.g. `go version`):
+  - Others:
+
+  </details>


### PR DESCRIPTION
We can initialize issue templates to help users respond to the problems they encounter